### PR TITLE
Merge fix/repeatExtensions to dev

### DIFF
--- a/contracts/extensions/extend/ExtendLogic.sol
+++ b/contracts/extensions/extend/ExtendLogic.sol
@@ -74,7 +74,7 @@ contract ExtendLogic is ExtendExtension {
         ExtendableState storage state = ExtendableStorage._getState();
         uint numberOfInterfacesImplemented = state.implementedInterfaceIds.length;
 
-        // collect all extension addresses
+        // collect unique extension addresses
         address[] memory extensions = new address[](numberOfInterfacesImplemented);
         uint numberOfUniqueExtensions;
         for (uint i = 0; i < numberOfInterfacesImplemented; i++) {
@@ -132,7 +132,7 @@ contract ExtendLogic is ExtendExtension {
         ExtendableState storage state = ExtendableStorage._getState();
         uint numberOfInterfacesImplemented = state.implementedInterfaceIds.length;
 
-        // collect all extension addresses
+        // collect unique extension addresses
         address[] memory extensions = new address[](numberOfInterfacesImplemented);
         uint numberOfUniqueExtensions;
         for (uint i = 0; i < numberOfInterfacesImplemented; i++) {
@@ -145,7 +145,6 @@ contract ExtendLogic is ExtendExtension {
         }
 
         address[] memory uniqueExtensions = new address[](numberOfUniqueExtensions);
-        // retrieve solidity interfaces of unique extensions
         for (uint i = 0; i < numberOfUniqueExtensions; i++) {
             uniqueExtensions[i] = extensions[i];
         }

--- a/contracts/extensions/extend/ExtendLogic.sol
+++ b/contracts/extensions/extend/ExtendLogic.sol
@@ -79,14 +79,15 @@ contract ExtendLogic is ExtendExtension {
         uint numberOfUniqueExtensions;
         for (uint i = 0; i < numberOfInterfacesImplemented; i++) {
             bytes4 interfaceId = state.implementedInterfaceIds[i];
-            extensions[i] = state.extensionContracts[interfaceId];
+            address extension = state.extensionContracts[interfaceId];
 
             // if we have seen this extension before, ignore and continue looping
-            if (i != 0 && exists(extensions[i], extensions, numberOfUniqueExtensions)) continue;
-            
-            IExtension logic = IExtension(extensions[i]);
-            fullInterface = string(abi.encodePacked(fullInterface, logic.getSolidityInterface()));
+            if (i != 0 && exists(extension, extensions, numberOfUniqueExtensions)) continue;
+            extensions[numberOfUniqueExtensions] = extension;
             numberOfUniqueExtensions++;
+            
+            IExtension logic = IExtension(extension);
+            fullInterface = string(abi.encodePacked(fullInterface, logic.getSolidityInterface()));
         }
 
         // TO-DO optimise this return to a standardised format with comments for developers
@@ -136,10 +137,10 @@ contract ExtendLogic is ExtendExtension {
         uint numberOfUniqueExtensions;
         for (uint i = 0; i < numberOfInterfacesImplemented; i++) {
             bytes4 interfaceId = state.implementedInterfaceIds[i];
-            extensions[i] = state.extensionContracts[interfaceId];
+            address extension = state.extensionContracts[interfaceId];
 
-            if (i != 0 && exists(extensions[i], extensions, numberOfUniqueExtensions)) continue;
-            extensions[numberOfUniqueExtensions] = extensions[i];
+            if (i != 0 && exists(extension, extensions, numberOfUniqueExtensions)) continue;
+            extensions[numberOfUniqueExtensions] = extension;
             numberOfUniqueExtensions++;
         }
 

--- a/contracts/mock/callers/ExtendCaller.sol
+++ b/contracts/mock/callers/ExtendCaller.sol
@@ -49,4 +49,16 @@ contract ExtendCaller is PermissioningCaller {
         address[] memory extensions = abi.decode(result, (address[]));
         return(extensions);
     }
+
+    function registerInterface(bytes4 iface) public {
+        (bool success, bytes memory result) = _extendLogic.delegatecall(abi.encodeWithSignature("registerInterface(bytes4)", iface));
+        Revert.require(success);
+    }
+
+    function supportsInterface(bytes4 iface) public returns(bool) {
+        (bool success, bytes memory result) = _extendLogic.delegatecall(abi.encodeWithSignature("supportsInterface(bytes4)", iface));
+        Revert.require(success);
+        bool supported = abi.decode(result, (bool));
+        return(supported);
+    }
 }

--- a/contracts/mock/extensions/MockExtension.sol
+++ b/contracts/mock/extensions/MockExtension.sol
@@ -18,12 +18,12 @@ contract MockExtension is IMockExtension, Extension {
         revert("normal reversion");
     }
     
-    function getSolidityInterface() override public pure returns(string memory) {
+    function getSolidityInterface() override virtual public pure returns(string memory) {
         return  "function test() external;\n"
                 "function reverts() external;\n";
     }
 
-    function getInterface() override public pure returns(Interface[] memory interfaces) {
+    function getInterface() override virtual public pure returns(Interface[] memory interfaces) {
         interfaces = new Interface[](1);
 
         bytes4[] memory functions = new bytes4[](2);
@@ -32,6 +32,36 @@ contract MockExtension is IMockExtension, Extension {
 
         interfaces[0] = Interface(
             type(IMockExtension).interfaceId,
+            functions
+        );
+    }
+}
+
+interface IMockSecondExtension {
+    function second() external;
+}
+
+contract MockSecondExtension is IMockSecondExtension, MockExtension {
+    function second() override public {
+        emit Test();
+    }
+    
+    function getSolidityInterface() override public pure returns(string memory) {
+        return string(abi.encodePacked(
+            MockExtension.getSolidityInterface(),
+            "function second() external;\n"
+        ));
+    }
+
+    function getInterface() override public pure returns(Interface[] memory interfaces) {
+        interfaces = new Interface[](2);
+
+        bytes4[] memory functions = new bytes4[](1);
+        functions[0] = IMockSecondExtension.second.selector;
+
+        interfaces[0] = MockExtension.getInterface()[0];
+        interfaces[1] = Interface(
+            type(IMockSecondExtension).interfaceId,
             functions
         );
     }

--- a/test/extendable.test.js
+++ b/test/extendable.test.js
@@ -129,6 +129,12 @@ describe("Extendable", function () {
                 "}"
             ));
         });
+
+        it("register interface should successfully register and return supports interface", async function () {
+            const extendableAsExtension = await utils.getExtendedContractWithInterface(extendableAddress, "ERC165Logic");
+            await expect(extendableAsExtension.registerInterface("0x80ac58cd")).to.not.be.reverted;
+            expect(await extendableAsExtension.callStatic.supportsInterface("0x80ac58cd")).to.be.true;
+        });
     })
 
     describe("retract", () => {

--- a/test/extensions/extend.test.js
+++ b/test/extensions/extend.test.js
@@ -78,6 +78,11 @@ describe("ExtendLogic", function () {
         ));
     });
 
+    it("register interface should successfully register and return supports interface", async function () {
+        await expect(caller.registerInterface("0x80ac58cd")).to.not.be.reverted;
+        expect(await caller.callStatic.supportsInterface("0x80ac58cd")).to.be.true;
+    });
+
     it("extend should fail with non-contract address", async function () {
         await expect(caller.callExtend(account.address)).to.be.revertedWith("Extend: address is not a contract");
         expect(await caller.callStatic.getExtensionsInterfaceIds()).to.deep.equal([EXTEND.INTERFACE]);

--- a/test/utils/constants.js
+++ b/test/utils/constants.js
@@ -8,6 +8,12 @@ module.exports = {
             "0x3bccbbc9"
         ]
     },
+    MOCK_SECOND_EXTENSION: {
+        INTERFACE: "0x5a8ac02d",
+        SELECTORS: [
+            "0x5a8ac02d"
+        ]
+    },
     EXTEND: {
         INTERFACE: "0xdc8f7254",
         SELECTORS: [


### PR DESCRIPTION
Fixed bug where extensions that implement multiple interfaces caused `getFullInterface` and `getExtensionAddresses` to be populated more than once for the same contract.

Added implicit extension of ERC165 introspection functions for Extendable.